### PR TITLE
Remove jenkins_init_file definitions from vars

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,7 +2,6 @@
 __jenkins_repo_url: deb https://pkg.jenkins.io/debian{{ '-stable' if (jenkins_prefer_lts | bool) else '' }} binary/
 __jenkins_repo_key_url: https://pkg.jenkins.io/debian{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.io-2023.key
 __jenkins_pkg_url: https://pkg.jenkins.io/debian/binary
-jenkins_init_file: /etc/default/jenkins
 jenkins_http_port_param: HTTP_PORT
 jenkins_https_port_param: HTTPS_PORT
 jenkins_https_crt_param: HTTPS_CRT

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,7 +2,6 @@
 __jenkins_repo_url: https://pkg.jenkins.io/redhat{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.repo
 __jenkins_repo_key_url: https://pkg.jenkins.io/redhat{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.io-2023.key
 __jenkins_pkg_url: https://pkg.jenkins.io/redhat
-jenkins_init_file: /etc/sysconfig/jenkins
 jenkins_http_port_param: JENKINS_PORT
 jenkins_https_port_param: JENKINS_HTTPS_PORT
 jenkins_https_crt_param: JENKINS_HTTPS_CRT


### PR DESCRIPTION
Jenkins 2.332.x (https://www.jenkins.io/doc/upgrade-guide/2.332/) switched to using systemd to manage Jenkins and it's configuration.

Remove jenkins_init_file from "vars" so that default init file path (in defaults/main.yml) is used.